### PR TITLE
Public landing + Auth0 SPA session lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ MVP foundation for Symptom Witch:
 2. Run API tests:
    - `cd api && ./gradlew test`
 3. Run web checks:
-   - `cd web && npm install && npm run lint && npm run test && npm run build`
+   - `cd web && cp .env.example .env && npm install && npm run lint && npm run test && npm run build`
 
 ## Lint and format
 

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,0 +1,2 @@
+VITE_AUTH0_DOMAIN=your-tenant.auth0.com
+VITE_AUTH0_CLIENT_ID=your-client-id

--- a/web/README.md
+++ b/web/README.md
@@ -24,8 +24,7 @@ Frontend for the Symptom Witch public landing and authenticated shell.
 
 ## Manual auth verification checklist
 
-- Logged out: `/` shows landing copy, `Log in`, `Sign up`, `Privacy`, and `Terms`
+- Logged out: `/` shows landing copy, `Log in`, `Privacy`, and `Terms`
 - `Log in` sends user through Auth0 and returns to `/` authenticated view
-- `Sign up` opens Auth0 Universal Login with signup intent
 - Authenticated: `/` shows shell with symptom draft form and `Sign out`
 - `Sign out` returns user to logged-out landing state

--- a/web/README.md
+++ b/web/README.md
@@ -1,73 +1,31 @@
-# React + TypeScript + Vite
+# Symptom Witch Web
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Frontend for the Symptom Witch public landing and authenticated shell.
 
-Currently, two official plugins are available:
+## Auth0 configuration
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Oxc](https://oxc.rs)
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/)
+1. Copy `.env.example` to `.env`:
+   - `cp .env.example .env`
+2. Fill in Auth0 SPA values:
+   - `VITE_AUTH0_DOMAIN`
+   - `VITE_AUTH0_CLIENT_ID`
+3. In the Auth0 application settings, configure:
+   - Allowed Callback URLs: `http://localhost:5173`
+   - Allowed Logout URLs: `http://localhost:5173`
+   - Allowed Web Origins: `http://localhost:5173`
+4. Enable refresh token rotation for the SPA in Auth0.
 
-## React Compiler
+## Scripts
 
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
+- `npm run dev`: run local dev server
+- `npm run test`: run unit tests
+- `npm run lint`: run ESLint + typecheck
+- `npm run build`: build production bundle
 
-## Expanding the ESLint configuration
+## Manual auth verification checklist
 
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
-```
-
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
-
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
-
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
-```
+- Logged out: `/` shows landing copy, `Log in`, `Sign up`, `Privacy`, and `Terms`
+- `Log in` sends user through Auth0 and returns to `/` authenticated view
+- `Sign up` opens Auth0 Universal Login with signup intent
+- Authenticated: `/` shows shell with symptom draft form and `Sign out`
+- `Sign out` returns user to logged-out landing state

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "web",
       "version": "0.0.0",
       "dependencies": {
+        "@auth0/auth0-react": "^2.16.2",
         "@base-ui/react": "^1.4.1",
         "@fontsource-variable/geist": "^5.2.8",
         "@tanstack/react-form": "^1.29.1",
@@ -104,6 +105,41 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@auth0/auth0-auth-js": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@auth0/auth0-auth-js/-/auth0-auth-js-1.6.0.tgz",
+      "integrity": "sha512-/WYYNlsqhWA6I60pMVLFVeOgjOUCLdJThEAsjN8pAgYY09BTxbPaRIEVDgGu6ckoJpkmKvEYlHPO/vwRNrvX6w==",
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^6.0.8",
+        "openid-client": "^6.8.0"
+      }
+    },
+    "node_modules/@auth0/auth0-react": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/@auth0/auth0-react/-/auth0-react-2.16.2.tgz",
+      "integrity": "sha512-Sp7aXuvSMXh0qO74wv25ZsNjCAX1HItU2LhHCvPAJKQYRr/Rc9b1OtdyhkkIXAlAYgQZ2qbC2P8hiDpRh54aAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@auth0/auth0-spa-js": "^2.19.2"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17 || ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1",
+        "react-dom": "^16.11.0 || ^17 || ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1"
+      }
+    },
+    "node_modules/@auth0/auth0-spa-js": {
+      "version": "2.19.2",
+      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-2.19.2.tgz",
+      "integrity": "sha512-NJOjPQZjZ8g2LXkBjNiYtf614WGVhwCg+q9L2MXcEQqey+ign9CG/wnl9OxYDz7XuItWecfYQLbiVTjIGNZ/Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "@auth0/auth0-auth-js": "1.6.0",
+        "browser-tabs-lock": "1.3.0",
+        "dpop": "2.1.1",
+        "es-cookie": "1.3.2"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -3189,6 +3225,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/browser-tabs-lock": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-tabs-lock/-/browser-tabs-lock-1.3.0.tgz",
+      "integrity": "sha512-g6nHaobTiT0eMZ7jh16YpD2kcjAp+PInbiVq3M1x6KKaEIVhT4v9oURNIpZLOZ3LQbQ3XYfNhMAb/9hzNLIWrw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": ">=4.17.21"
+      }
+    },
     "node_modules/browserslist": {
       "version": "4.28.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
@@ -3795,6 +3841,15 @@
         "url": "https://dotenvx.com"
       }
     },
+    "node_modules/dpop": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/dpop/-/dpop-2.1.1.tgz",
+      "integrity": "sha512-J0Of2JTiM4h5si0tlbPQ/lkqfZ5wAEVkKYBhkwyyANnPJfWH4VsR5uIkZ+T+OSPIwDYUg1fbd5Mmodd25HjY1w==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -3897,6 +3952,12 @@
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
+    },
+    "node_modules/es-cookie": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/es-cookie/-/es-cookie-1.3.2.tgz",
+      "integrity": "sha512-UTlYYhXGLOy05P/vKVT2Ui7WtC7NiRzGtJyAKKn32g5Gvcjn7KAClLPWlipCtxIus934dFg9o9jXiBL0nP+t9Q==",
+      "license": "MIT"
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
@@ -5663,6 +5724,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
     "node_modules/log-symbols": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
@@ -6065,6 +6132,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.5.tgz",
+      "integrity": "sha512-A8jmyUckVhRJj5lspguklcl90Ydqk61H3dcU0oLhH3Yv13KpAliKTt5hknpGGPZSSfOwGyraNEFmofDYH+1kSg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -6160,6 +6236,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openid-client": {
+      "version": "6.8.3",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.8.3.tgz",
+      "integrity": "sha512-AoY/NaN9esS3+xvHInFSK0g3skSfeE0uqQAKRj4rB6/GsBIvzwTUaYo9+HcqpKIaP0dP85p5W07hayKgS4GAeA==",
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^6.2.2",
+        "oauth4webapi": "^3.8.5"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/optionator": {

--- a/web/package.json
+++ b/web/package.json
@@ -15,6 +15,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@auth0/auth0-react": "^2.16.2",
     "@base-ui/react": "^1.4.1",
     "@fontsource-variable/geist": "^5.2.8",
     "@tanstack/react-form": "^1.29.1",

--- a/web/src/auth/auth0-provider.test.tsx
+++ b/web/src/auth/auth0-provider.test.tsx
@@ -1,0 +1,51 @@
+import { render } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { Auth0AppProvider, getAuth0RuntimeConfig } from '@/auth/auth0-provider'
+
+const auth0ProviderSpy = vi.hoisted(() => vi.fn())
+
+vi.mock('@auth0/auth0-react', () => ({
+  Auth0Provider: ({ children, ...props }: { children: ReactNode }) => {
+    auth0ProviderSpy(props)
+    return <>{children}</>
+  },
+}))
+
+describe('Auth0AppProvider', () => {
+  it('configures Auth0Provider with refresh token support', () => {
+    render(
+      <Auth0AppProvider config={{ domain: 'example.auth0.com', clientId: 'client-123' }}>
+        <div>child</div>
+      </Auth0AppProvider>,
+    )
+
+    expect(auth0ProviderSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        domain: 'example.auth0.com',
+        clientId: 'client-123',
+        cacheLocation: 'memory',
+        useRefreshTokens: true,
+        authorizationParams: { redirect_uri: window.location.origin },
+      }),
+    )
+  })
+
+  it('reads runtime config from vite environment variables', () => {
+    const config = getAuth0RuntimeConfig({
+      BASE_URL: '/',
+      MODE: 'test',
+      DEV: false,
+      PROD: false,
+      SSR: false,
+      VITE_AUTH0_DOMAIN: 'tenant.auth0.com',
+      VITE_AUTH0_CLIENT_ID: 'client-id',
+    } as ImportMetaEnv)
+
+    expect(config).toEqual({
+      domain: 'tenant.auth0.com',
+      clientId: 'client-id',
+    })
+  })
+})

--- a/web/src/auth/auth0-provider.tsx
+++ b/web/src/auth/auth0-provider.tsx
@@ -1,0 +1,33 @@
+import { Auth0Provider } from '@auth0/auth0-react'
+import type { ReactNode } from 'react'
+
+export interface Auth0RuntimeConfig {
+  domain: string
+  clientId: string
+}
+
+export function getAuth0RuntimeConfig(env: ImportMetaEnv = import.meta.env): Auth0RuntimeConfig {
+  return {
+    domain: env.VITE_AUTH0_DOMAIN ?? '',
+    clientId: env.VITE_AUTH0_CLIENT_ID ?? '',
+  }
+}
+
+interface Auth0AppProviderProps {
+  children: ReactNode
+  config?: Auth0RuntimeConfig
+}
+
+export function Auth0AppProvider({ children, config = getAuth0RuntimeConfig() }: Auth0AppProviderProps) {
+  return (
+    <Auth0Provider
+      domain={config.domain}
+      clientId={config.clientId}
+      cacheLocation="memory"
+      useRefreshTokens={true}
+      authorizationParams={{ redirect_uri: window.location.origin }}
+    >
+      {children}
+    </Auth0Provider>
+  )
+}

--- a/web/src/auth/auth0-provider.tsx
+++ b/web/src/auth/auth0-provider.tsx
@@ -18,7 +18,10 @@ interface Auth0AppProviderProps {
   config?: Auth0RuntimeConfig
 }
 
-export function Auth0AppProvider({ children, config = getAuth0RuntimeConfig() }: Auth0AppProviderProps) {
+export function Auth0AppProvider({
+  children,
+  config = getAuth0RuntimeConfig(),
+}: Auth0AppProviderProps) {
   return (
     <Auth0Provider
       domain={config.domain}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -4,6 +4,7 @@ import './index.css'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { RouterProvider } from '@tanstack/react-router'
 
+import { Auth0AppProvider } from '@/auth/auth0-provider'
 import { router } from '@/router'
 
 const queryClient = new QueryClient()
@@ -11,7 +12,9 @@ const queryClient = new QueryClient()
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
+      <Auth0AppProvider>
+        <RouterProvider router={router} />
+      </Auth0AppProvider>
     </QueryClientProvider>
   </StrictMode>,
 )

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -1,6 +1,8 @@
 import { createRootRoute, createRoute, createRouter, Outlet } from '@tanstack/react-router'
 
 import { HomeRouteView } from '@/routes/home'
+import { PrivacyRouteView } from '@/routes/privacy'
+import { TermsRouteView } from '@/routes/terms'
 
 const rootRoute = createRootRoute({
   component: () => <Outlet />,
@@ -12,7 +14,19 @@ const indexRoute = createRoute({
   component: HomeRouteView,
 })
 
-const routeTree = rootRoute.addChildren([indexRoute])
+const privacyRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/privacy',
+  component: PrivacyRouteView,
+})
+
+const termsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/terms',
+  component: TermsRouteView,
+})
+
+const routeTree = rootRoute.addChildren([indexRoute, privacyRoute, termsRoute])
 
 export const router = createRouter({ routeTree })
 

--- a/web/src/routes/home.test.tsx
+++ b/web/src/routes/home.test.tsx
@@ -1,11 +1,77 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { render, screen } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { HomeRouteView } from '@/routes/home'
 
+const authState = vi.hoisted(() => {
+  return {
+    isAuthenticated: false,
+    loginWithRedirect: vi.fn(),
+    logout: vi.fn(),
+  }
+})
+
+vi.mock('@auth0/auth0-react', () => ({
+  useAuth0: () => ({
+    isAuthenticated: authState.isAuthenticated,
+    isLoading: false,
+    loginWithRedirect: authState.loginWithRedirect,
+    logout: authState.logout,
+    user: undefined,
+  }),
+}))
+
 describe('HomeRouteView', () => {
-  it('renders the shell and symptom draft form', async () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  beforeEach(() => {
+    authState.isAuthenticated = false
+    authState.loginWithRedirect.mockReset()
+    authState.logout.mockReset()
+  })
+
+  it('renders the public landing content for logged-out users', async () => {
+    const queryClient = new QueryClient()
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <HomeRouteView />
+      </QueryClientProvider>,
+    )
+
+    expect(await screen.findByText('Symptom Witch shell is ready')).toBeInTheDocument()
+    expect(screen.getByText('Track patterns before symptoms escalate.')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Log in' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Sign up' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Privacy' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Terms' })).toBeInTheDocument()
+  })
+
+  it('starts login and signup with Auth0 redirect', async () => {
+    const queryClient = new QueryClient()
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <HomeRouteView />
+      </QueryClientProvider>,
+    )
+
+    await screen.findByText('Symptom Witch shell is ready')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Log in' }))
+    expect(authState.loginWithRedirect).toHaveBeenCalledWith()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sign up' }))
+    expect(authState.loginWithRedirect).toHaveBeenLastCalledWith({
+      authorizationParams: { screen_hint: 'signup' },
+    })
+  })
+
+  it('renders the shell and supports sign out for authenticated users', async () => {
+    authState.isAuthenticated = true
     const queryClient = new QueryClient()
 
     render(
@@ -16,6 +82,12 @@ describe('HomeRouteView', () => {
 
     expect(await screen.findByText('Symptom Witch shell is ready')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Save draft' })).toBeInTheDocument()
-    expect(screen.getByPlaceholderText('Headache')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Log in' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Sign up' })).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sign out' }))
+    expect(authState.logout).toHaveBeenCalledWith({
+      logoutParams: { returnTo: window.location.origin },
+    })
   })
 })

--- a/web/src/routes/home.test.tsx
+++ b/web/src/routes/home.test.tsx
@@ -45,12 +45,12 @@ describe('HomeRouteView', () => {
     expect(await screen.findByText('Symptom Witch shell is ready')).toBeInTheDocument()
     expect(screen.getByText('Track patterns before symptoms escalate.')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Log in' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Sign up' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Sign up' })).not.toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'Privacy' })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'Terms' })).toBeInTheDocument()
   })
 
-  it('starts login and signup with Auth0 redirect', async () => {
+  it('starts login with Auth0 redirect', async () => {
     const queryClient = new QueryClient()
 
     render(
@@ -63,11 +63,6 @@ describe('HomeRouteView', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Log in' }))
     expect(authState.loginWithRedirect).toHaveBeenCalledWith()
-
-    fireEvent.click(screen.getByRole('button', { name: 'Sign up' }))
-    expect(authState.loginWithRedirect).toHaveBeenLastCalledWith({
-      authorizationParams: { screen_hint: 'signup' },
-    })
   })
 
   it('renders the shell and supports sign out for authenticated users', async () => {
@@ -83,7 +78,6 @@ describe('HomeRouteView', () => {
     expect(await screen.findByText('Symptom Witch shell is ready')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Save draft' })).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Log in' })).not.toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: 'Sign up' })).not.toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'Sign out' }))
     expect(authState.logout).toHaveBeenCalledWith({

--- a/web/src/routes/home.tsx
+++ b/web/src/routes/home.tsx
@@ -85,7 +85,10 @@ export function HomeRouteView() {
             >
               Sign up
             </Button>
-            <a className="text-sm text-muted-foreground underline underline-offset-2" href="/privacy">
+            <a
+              className="text-sm text-muted-foreground underline underline-offset-2"
+              href="/privacy"
+            >
               Privacy
             </a>
             <a className="text-sm text-muted-foreground underline underline-offset-2" href="/terms">

--- a/web/src/routes/home.tsx
+++ b/web/src/routes/home.tsx
@@ -74,17 +74,6 @@ export function HomeRouteView() {
             <Button type="button" onClick={() => void loginWithRedirect()}>
               Log in
             </Button>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() =>
-                void loginWithRedirect({
-                  authorizationParams: { screen_hint: 'signup' },
-                })
-              }
-            >
-              Sign up
-            </Button>
             <a
               className="text-sm text-muted-foreground underline underline-offset-2"
               href="/privacy"

--- a/web/src/routes/home.tsx
+++ b/web/src/routes/home.tsx
@@ -1,5 +1,6 @@
 import { useForm } from '@tanstack/react-form'
 import { useQuery } from '@tanstack/react-query'
+import { useAuth0 } from '@auth0/auth0-react'
 
 import { Button } from '@/components/ui/button'
 
@@ -8,6 +9,7 @@ function fetchWelcomeMessage(): Promise<string> {
 }
 
 export function HomeRouteView() {
+  const { isAuthenticated, loginWithRedirect, logout } = useAuth0()
   const messageQuery = useQuery({
     queryKey: ['welcome-message'],
     queryFn: fetchWelcomeMessage,
@@ -27,31 +29,71 @@ export function HomeRouteView() {
         <p className="text-muted-foreground">{messageQuery.data ?? 'Loading app status...'}</p>
       </header>
 
-      <form
-        className="flex flex-col gap-4 rounded-lg border p-4"
-        onSubmit={(event) => {
-          event.preventDefault()
-          event.stopPropagation()
-          form.handleSubmit()
-        }}
-      >
-        <form.Field name="symptomName">
-          {(field) => (
-            <label className="flex flex-col gap-2 text-sm">
-              Symptom to track
-              <input
-                className="h-10 rounded-md border bg-background px-3"
-                name={field.name}
-                value={field.state.value}
-                onBlur={field.handleBlur}
-                onChange={(event) => field.handleChange(event.target.value)}
-                placeholder="Headache"
-              />
-            </label>
-          )}
-        </form.Field>
-        <Button type="submit">Save draft</Button>
-      </form>
+      {isAuthenticated ? (
+        <>
+          <section className="flex items-center justify-end">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => logout({ logoutParams: { returnTo: window.location.origin } })}
+            >
+              Sign out
+            </Button>
+          </section>
+
+          <form
+            className="flex flex-col gap-4 rounded-lg border p-4"
+            onSubmit={(event) => {
+              event.preventDefault()
+              event.stopPropagation()
+              form.handleSubmit()
+            }}
+          >
+            <form.Field name="symptomName">
+              {(field) => (
+                <label className="flex flex-col gap-2 text-sm">
+                  Symptom to track
+                  <input
+                    className="h-10 rounded-md border bg-background px-3"
+                    name={field.name}
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={(event) => field.handleChange(event.target.value)}
+                    placeholder="Headache"
+                  />
+                </label>
+              )}
+            </form.Field>
+            <Button type="submit">Save draft</Button>
+          </form>
+        </>
+      ) : (
+        <section className="flex flex-col gap-4 rounded-lg border p-4">
+          <p className="text-sm text-muted-foreground">Track patterns before symptoms escalate.</p>
+          <div className="flex flex-wrap items-center gap-3">
+            <Button type="button" onClick={() => void loginWithRedirect()}>
+              Log in
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() =>
+                void loginWithRedirect({
+                  authorizationParams: { screen_hint: 'signup' },
+                })
+              }
+            >
+              Sign up
+            </Button>
+            <a className="text-sm text-muted-foreground underline underline-offset-2" href="/privacy">
+              Privacy
+            </a>
+            <a className="text-sm text-muted-foreground underline underline-offset-2" href="/terms">
+              Terms
+            </a>
+          </div>
+        </section>
+      )}
     </main>
   )
 }

--- a/web/src/routes/legal.test.tsx
+++ b/web/src/routes/legal.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { PrivacyRouteView } from '@/routes/privacy'
+import { TermsRouteView } from '@/routes/terms'
+
+describe('Legal routes', () => {
+  it('renders the privacy placeholder page content', () => {
+    render(<PrivacyRouteView />)
+
+    expect(screen.getByRole('heading', { name: 'Privacy' })).toBeInTheDocument()
+    expect(screen.getByText('Privacy details are coming soon.')).toBeInTheDocument()
+  })
+
+  it('renders the terms placeholder page content', () => {
+    render(<TermsRouteView />)
+
+    expect(screen.getByRole('heading', { name: 'Terms' })).toBeInTheDocument()
+    expect(screen.getByText('Terms of use are coming soon.')).toBeInTheDocument()
+  })
+})

--- a/web/src/routes/privacy.tsx
+++ b/web/src/routes/privacy.tsx
@@ -1,0 +1,11 @@
+export function PrivacyRouteView() {
+  return (
+    <main className="mx-auto flex min-h-screen w-full max-w-3xl flex-col gap-4 px-6 py-10">
+      <h1 className="text-2xl font-semibold">Privacy</h1>
+      <p className="text-muted-foreground">Privacy details are coming soon.</p>
+      <a className="text-sm underline underline-offset-2" href="/">
+        Back to home
+      </a>
+    </main>
+  )
+}

--- a/web/src/routes/terms.tsx
+++ b/web/src/routes/terms.tsx
@@ -1,0 +1,11 @@
+export function TermsRouteView() {
+  return (
+    <main className="mx-auto flex min-h-screen w-full max-w-3xl flex-col gap-4 px-6 py-10">
+      <h1 className="text-2xl font-semibold">Terms</h1>
+      <p className="text-muted-foreground">Terms of use are coming soon.</p>
+      <a className="text-sm underline underline-offset-2" href="/">
+        Back to home
+      </a>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary

- Wrap the web app with an `Auth0AppProvider` (memory cache, `useRefreshTokens=true`, PKCE redirect) and expose env-driven runtime config in `web/src/auth/auth0-provider.tsx`.
- Render a public landing on `/` for logged-out users with `Log in` and links to `Privacy`/`Terms`; keep the existing shell plus `Sign out` on `/` for authenticated users.
- Add placeholder `/privacy` and `/terms` routes and register them in the TanStack router.
- Document required `VITE_AUTH0_DOMAIN`/`VITE_AUTH0_CLIENT_ID`, dashboard callback/logout/web-origin setup, and a manual auth verification checklist in `web/README.md` + `.env.example`.
- Tests: Vitest + Testing Library cover logged-out landing, login CTA behavior, authenticated shell with sign-out, legal placeholder pages, and Auth0 provider config wiring.

## Notes

- Signup is disabled at the Auth0 tenant, so the public landing intentionally exposes only a single `Log in` entry point.

## Test plan

- [x] `cd web && npm run test`
- [x] `cd web && npm run lint` (eslint + typecheck)
- [x] `cd web && npm run format:check`
- [x] `cd web && npm run build`
- [ ] Manual: copy `.env.example` to `.env`, set real Auth0 values, and run through the checklist in `web/README.md` (login, sign out, refresh token rotation).

Closes #2